### PR TITLE
refactor: using `importSource` to replace `resolve.alias`

### DIFF
--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -15,14 +15,6 @@ export default {
     filename: "main.js",
     path: path.resolve(__dirname, "dist"),
   },
-  resolve: {
-    alias: {
-      react: "preact/compat",
-      "react-dom/test-utils": "preact/test-utils",
-      "react-dom": "preact/compat",
-      "react/jsx-runtime": "preact/jsx-runtime",
-    },
-  },
   module: {
     rules: [
       {
@@ -42,6 +34,7 @@ export default {
             transform: {
               react: {
                 runtime: "automatic",
+                importSource: 'preact'
               },
             },
           },
@@ -61,6 +54,7 @@ export default {
             transform: {
               react: {
                 runtime: "automatic",
+                importSource: 'preact'
               },
             },
           },


### PR DESCRIPTION
# Summary

## Using `babel-loader` and `@babel/transform-react-jsx`

The key configuration is as follows:

```js
module.exports = {
  module: {
    rules: [
      {
        test: /.jsx?$/,
        exclude: /node_modules/,
        use: {
          loader: "babel-loader",
          options: {
            plugins: [
              [
                "@babel/transform-react-jsx",
                {
                  runtime: "automatic",
                  importSource: "preact",
                },
              ],
            ],
          },
        },
      },
    ],
  },
};
```

## Using `importSource` instead of **`resolve.alias`**

Assuming the source code is as follows:

```js
import { render } from "preact";

function App() {
  return (
    <div>
      <a href="https://preactjs.com" target="_blank">
        <img alt="Preact logo" height="160" width="160" src={preactLogo} />
      </a>
    </div>
  );
}

render(<App />, document.getElementById("app"));
```

It will be compiled into:

```js
import { render } from "preact";

import { jsx as _jsx } from "preact/jsx-runtime";
import { jsxs as _jsxs } from "preact/jsx-runtime";

function App() {
  return _jsx("div", {
    children: _jsx("a", {
      href: "https://preactjs.com",
      target: "_blank",
      children: _jsx("img", {
        alt: "Preact logo",
        height: "160",
        width: "160",
        src: preactLogo
      })
    })
  });
}

render(_jsx(App, {}), document.getElementById("app"));
```

The compilation output is due to [@babel/transform-react-jsx](https://babeljs.io/docs/babel-plugin-transform-react-jsx#react-automatic-runtime-1) setting the `runtime` option to `automatic` and setting `importSource` to `preact`. The implementation can be found [here](https://github.com/babel/babel/blob/c446ff85c28e117ebf3cd72cd34ef358f1077aa8/packages/babel-plugin-transform-react-jsx/src/create-plugin.ts#L250C1-L256C49):

```js
  const define = (name: string, id: string) =>
        set(state, name, createImportLazily(state, path, id, source));

      define("id/jsx", development ? "jsxDEV" : "jsx");
      define("id/jsxs", development ? "jsxDEV" : "jsxs");
      define("id/createElement", "createElement");
      define("id/fragment", "Fragment");
```

The `createImportLazily` function depends on the `getSource` function implementation:

```js
  function getSource(source: string, importName: string) {
    switch (importName) {
      case "Fragment":
        return `${source}/${development ? "jsx-dev-runtime" : "jsx-runtime"}`;
      case "jsxDEV":
        return `${source}/jsx-dev-runtime`;
      case "jsx":
      case "jsxs":
        return `${source}/jsx-runtime`;
      case "createElement":
        return source;
    }
  }
```

In other words, the behavior of [@babel/transform-react-jsx](https://babeljs.io/docs/babel-plugin-transform-react-jsx#react-automatic-runtime-1)'s `importSource: 'preact'` can also be achieved with Webpack's `alias`, as follows:

```js
  resolve: {
    alias: {
      "react/jsx-runtime": "preact/jsx-runtime",
      "react/jsx-dev-runtime": "preact/jsx-dev-runtime",
    },
  },
```

**It is recommended to use the `importSource` of [@babel/transform-react-jsx](https://babeljs.io/docs/babel-plugin-transform-react-jsx#react-automatic-runtime-1) to generate precise imports in one go, rather than relying on `resolve.alias` for a second redirection.**

So when do you need to configure `resolve.alias`? — When you want to silently switch from React to Preact at runtime without modifying a React project's code.

